### PR TITLE
Remove deprecated "gauge.hooks" declaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 dependencies {
     testImplementation 'com.thoughtworks.gauge:gauge-java:+'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'net.sourceforge.htmlunit:htmlunit:2.29'
+    testImplementation 'net.sourceforge.htmlunit:htmlunit:2.39.0'
     testImplementation 'se.fishtank:css-selectors:2.0'
     testImplementation 'org.jsoup:jsoup:1.8.3'
     testImplementation 'org.assertj:assertj-core:3.4.1'

--- a/src/test/java/com/thoughtworks/gauge/test/common/JavascriptProject.java
+++ b/src/test/java/com/thoughtworks/gauge/test/common/JavascriptProject.java
@@ -127,7 +127,7 @@ public class JavascriptProject extends GaugeProject {
 
     public void createHook(String hookLevel, String hookType, String printString, String aggregation, List<String> tags) throws IOException {
         StringBuilder jsFileText = new StringBuilder();
-        jsFileText.append(String.format("gauge.hooks.%s%s(function () {", hookType.toLowerCase(), toTitleCase(hookLevel)));
+        jsFileText.append(String.format("%s%s(function () {", hookType.toLowerCase(), toTitleCase(hookLevel)));
         jsFileText.append(String.format("  console.log(\"%s\");\n", printString));
         jsFileText.append(String.format("}, %s);\n", getOptions(aggregation, tags)));
         Util.writeToFile(Util.combinePath(getStepImplementationsDir(), Util.getUniqueName() + ".js"), jsFileText.toString());


### PR DESCRIPTION
The deprecated usage of hooks

```
gauge.hooks.beforeScenario
```

is now removed from gauge js plugin.

This change also has upgrade of the htmlunit
library to solve the following warning

```
WARNING: Illegal reflective access
```
Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>