### PR TITLE
Revert "Bump the java-deps group with 2 updates"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.gauge' version '2.3.0'
+    id 'org.gauge' version '2.1.0'
 }
 
 repositories {
@@ -13,7 +13,7 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     testImplementation 'com.thoughtworks.gauge:gauge-java:+'
-    testImplementation 'org.htmlunit:htmlunit:4.13.0'
+    testImplementation 'org.htmlunit:htmlunit:4.12.0'
     testImplementation 'se.fishtank:css-selectors:2.0'
     testImplementation 'org.jsoup:jsoup:1.20.1'
     testImplementation 'org.assertj:assertj-core:3.27.3'


### PR DESCRIPTION
Reverts getgauge/gauge-tests#132

@haroon-sheikh reverting this, it broke tests and I dont have time to figure out why right now:

```
* Where:
Build file '/home/runner/work/gauge-ruby/gauge-ruby/gauge-tests/build.gradle' line: 71

* What went wrong:
A problem occurred evaluating root project 'gauge-tests'.
> Could not set unknown property 'testClassesDirs' for task ':gauge' of type org.gauge.gradle.GaugeTask.
```

https://github.com/getgauge/gauge-ruby/actions/runs/15446139072/job/43477569209