### PR TITLE
Only validate keyword words in step validations messages

### DIFF
--- a/specs/terminologies/scenarios/validation.spec
+++ b/specs/terminologies/scenarios/validation.spec
@@ -18,10 +18,12 @@ Validation Failure
 * Check for validation errors in the project and ensure failure
 * Console should contain following lines in order 
 
-   |Console output                                |
-   |----------------------------------------------|
-   |Step implementation not found => 'First Step' |
-   |Step implementation not found => 'Second Step'|
+   |Console output                |
+   |------------------------------|
+   |Step implementation not found |
+   |=> 'First Step'               |
+   |Step implementation not found |
+   |=> 'Second Step'              |
 
 Validation Success
 ------------------

--- a/specs/terminologies/specifications/basic_specs.spec
+++ b/specs/terminologies/specifications/basic_specs.spec
@@ -98,10 +98,12 @@ Spec should be skipped if it has all scenarios with unimplemented steps
 
 * Console should contain following lines in order 
 
-   |console output                               |
-   |---------------------------------------------|
-   |Step implementation not found => 'some step1'|
-   |Step implementation not found => 'some step2'|
+   |console output                |
+   |------------------------------|
+   |Step implementation not found |
+   |=> 'some step1'               |
+   |Step implementation not found |
+   |=> 'some step2'               |
 
 * Statistics generated should have 
 

--- a/specs/terminologies/specifications/validation.spec
+++ b/specs/terminologies/specifications/validation.spec
@@ -25,12 +25,14 @@ Spec execution with unimplemented step in scenarios
 * Execute the spec "Basic spec execution" and ensure success
 * Console should contain following lines in order 
 
-   |console output                                              |
-   |------------------------------------------------------------|
-   |Step implementation not found => 'First unimplemented step' |
-   |Step implementation not found => 'Second unimplemented step'|
-   |inside first step                                           |
-   |inside second step                                          |
+   |console output                       |
+   |-------------------------------------|
+   |Step implementation not found        |
+   |=> 'First unimplemented step'        |
+   |Step implementation not found        |
+   |=> 'Second unimplemented step'       |
+   |inside first step                    |
+   |inside second step                   |
 
 * Statistics generated should have 
 
@@ -66,9 +68,10 @@ Spec execution with unimplemented step in context step
 * Execute the spec "Basic spec execution" and ensure success
 * Console should contain following lines in order 
 
-   |console output                                  |
-   |------------------------------------------------|
-   |Step implementation not found => 'First context'|
+   |console output                |
+   |------------------------------|
+   |Step implementation not found |
+   |=> 'First context'            |
 
 * Statistics generated should have 
 
@@ -110,10 +113,12 @@ Spec execution with unimplemented step in context step and scenario
 * Execute the spec "Basic spec execution" and ensure success
 * Console should contain following lines in order 
 
-   |console output                                              |
-   |------------------------------------------------------------|
-   |Step implementation not found => 'First context'            |
-   |Step implementation not found => 'Second unimplemented step'|
+   |console output                       |
+   |-------------------------------------|
+   |Step implementation not found        |
+   |=> 'First context'                   |
+   |Step implementation not found        |
+   |=> 'Second unimplemented step'       |
 
 * Statistics generated should have 
 
@@ -176,12 +181,16 @@ Skip spec if all scenarios are skipped
 * Execute the spec "Basic spec execution" and ensure success
 * Console should contain following lines in order 
 
-   |console output                                              |
-   |------------------------------------------------------------|
-   |Step implementation not found => 'First unimplemented step' |
-   |Step implementation not found => 'Second unimplemented step'|
-   |Step implementation not found => 'Third unimplemented step' |
-   |Step implementation not found => 'Fourth unimplemented step'|
+   |console output                       |
+   |-------------------------------------|
+   |Step implementation not found        |
+   |=> 'First unimplemented step'        |
+   |Step implementation not found        |
+   |=> 'Second unimplemented step'       |
+   |Step implementation not found        |
+   |=> 'Third unimplemented step'        |
+   |Step implementation not found        |
+   |=> 'Fourth unimplemented step'       |
 
 * Statistics generated should have 
 

--- a/specs/terminologies/teardown_execution.spec
+++ b/specs/terminologies/teardown_execution.spec
@@ -73,10 +73,12 @@ Unimplemented teardown execution
 * Execute the spec "basic teardown execution" and ensure success
 * Console should contain following lines in order 
 
-   |console output                                    |
-   |--------------------------------------------------|
-   |Step implementation not found => 'First teardown' |
-   |Step implementation not found => 'Second teardown'|
+   |console output                |
+   |------------------------------|
+   |Step implementation not found |
+   |=> 'First teardown'           |
+   |Step implementation not found |
+   |=> 'Second teardown'          |
 
 
 * Statistics generated should have 


### PR DESCRIPTION
This PR https://github.com/getgauge/gauge/pull/2837 means that `ErrorMessage` from `StepValidateResponse` appears in validation output. 

Different  language runners provide different error messages for step validation failures, so assertions should verify the key parts independently rather than assuming a single-line format.

Approach:

* Split "Step implementation not found => 'step name'" console assertions into two separate substring checks: "Step implementation not found" and "=> 'step name'".

* This accommodates runners that include additional error details (e.g. the JS runner appends "Invalid step.") between the error type and the step reference, which breaks the single-line assertion.
